### PR TITLE
[FIX] RCE using execFile()

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -48,8 +48,10 @@ function execCommand(command, options) {
       shell: options.shell
     };
 
+    command = command.split(' ');
+
     if (options.sync || options.endless) {
-      var commandResult = child_process.execSync(command);
+      var commandResult = child_process.execFileSync(command[0], command.slice(1));
       var error = null;
 
       if (commandResult.status) {
@@ -58,7 +60,7 @@ function execCommand(command, options) {
 
       resolve({error: error, report: commandResult.stdout});
     } else {
-      child_process.exec(command, commandOptions, function(error, report) {
+      child_process.execFile(command[0], command.slice(1), commandOptions, function(error, report) {
         resolve({error: error, report: report});
       });
     }


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-gulp-scss-lint

### ⚙️ Description *

The `gulp-scss-lint` module was vulnerable against `arbitrary command injection` due to the fact `user supplied` inputs were taken and formatted inside a command which was then executed without proper checks.

### 💻 Technical Description *

I replaced `exec()` with `execFile()` in order to avoid that `malicious authors` could execute commands which don't use the `scss-lint` command (used by the library it-self).

### 🐛 Proof of Concept (PoC) *

```js
var root = require("gulp-scss-lint");
var attack_code = "echo vulnerable > create.txt";
var opt = {
  "src": attack_code
}
root(opt);
```

![Screenshot from 2020-09-04 15-15-00](https://user-images.githubusercontent.com/33063403/92244772-a3102880-eec3-11ea-8596-846be7c2be60.png)

### 🔥 Proof of Fix (PoF) *

Same PoC with fixed version doesn't lead to RCE:

![Screenshot from 2020-09-04 15-26-16](https://user-images.githubusercontent.com/33063403/92244805-b0c5ae00-eec3-11ea-976f-fa539cc04610.png)

### 👍 User Acceptance Testing (UAT)

All OK since `execFile` is used :smile:

**Notes:** The error you can see on the 2' screen is due to the fact I haven't installed the `scss-lint` utility :+1: 